### PR TITLE
[fix] おつまみ一覧画面の機能修正

### DIFF
--- a/app/views/snacks/_show.html.erb
+++ b/app/views/snacks/_show.html.erb
@@ -14,9 +14,6 @@
             <% else %>
               <%= image_tag "default.png", size: '600x600', class: 'card-img-top' %>
             <% end %>
-            <div class="bookmark-<%= @snack.id %> show-bookmark-position">
-              <%= render 'bookmarks/bookmark_area', snack: @snack %>
-            </div>
         </div>
         <div class="col-xl-6 col-md-12">
           <div class="container snack-container">

--- a/app/views/snacks/index.js.erb
+++ b/app/views/snacks/index.js.erb
@@ -1,7 +1,13 @@
 <% if @search_snacks_form.attributes.values == [nil] %>
   $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
 <% else %>
-  $('#records_table').html("<%= j(render @snack, snack: @snack)%>");
+  <% if @pagy.page == 1 %>
+    $('#records_table').html("<%= j(render @snack, snack: @snack)%>");
+  <% elsif @pagy.page > 2 %>
+    $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
+  <% else %>
+    $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
+  <% end %>
 <% end %>
 $('#div_next_link').html("<%= j(render 'next_link') %>");
 $("#pageScroll").attr('data-page', "<%=@next_page%>");

--- a/app/views/snacks/index.js.erb
+++ b/app/views/snacks/index.js.erb
@@ -1,13 +1,7 @@
-<% if @search_snacks_form.attributes.values == [nil] %>
-  $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
+<% if @pagy.page == 1 %>
+  $('#records_table').html("<%= j(render @snack, snack: @snack)%>");
 <% else %>
-  <% if @pagy.page == 1 %>
-    $('#records_table').html("<%= j(render @snack, snack: @snack)%>");
-  <% elsif @pagy.page > 2 %>
-    $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
-  <% else %>
-    $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
-  <% end %>
+  $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
 <% end %>
 $('#div_next_link').html("<%= j(render 'next_link') %>");
 $("#pageScroll").attr('data-page', "<%=@next_page%>");


### PR DESCRIPTION
・一覧画面で2ページ以上検索結果が表示されるときに、無限スクロールが適応しないことの修正
・おつまみ詳細からbookmarkの削除

```
# index.js.erb
<% if @pagy.page == 1 %>
  $('#records_table').html("<%= j(render @snack, snack: @snack)%>");
<% else %>
  $('#records_table').append("<%= j(render @snack, snack: @snack)%>");
<% end %>
$('#div_next_link').html("<%= j(render 'next_link') %>");
$("#pageScroll").attr('data-page', "<%=@next_page%>");

```
検索結果の1ページ目をhtml()で書き換え、2ページ目以降はappend()で追加する条件分岐で解決。


[メモ]
一覧の無限スクロールの挙動。
→Snacks#indexで1ページ目のおつまみを取得
→ユーザーがスクロールし、最下部が画面に入った時にJS発火
→JSで次のページのページネーションをクリック(非表示)(data-remote="true")
→Snacks#indexで2ページ目のおつまみを取得
→index.js.erbで上で取得した2ページ目のおつまみをappend()で追加
→表示